### PR TITLE
ejemplo de rel OneToMany Bidireccional que no aplica la relacion

### DIFF
--- a/src/main/java/org/example/modelo/Empleado.java
+++ b/src/main/java/org/example/modelo/Empleado.java
@@ -16,9 +16,10 @@ public class Empleado {
     private String nombre;
     @Column(name = "fecha_nacimiento")
     private Date fechaNacimiento;
-    @OneToMany(orphanRemoval = true)
+    @OneToMany(mappedBy = "empleado", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<Libro> libros;
     public Empleado() {
+        libros = new ArrayList<>();
     }
 
     public Empleado(java.lang.Long codigo, String apellidos, String nombre, Date fechaNacimiento) {

--- a/src/main/java/org/example/modelo/Libro.java
+++ b/src/main/java/org/example/modelo/Libro.java
@@ -11,6 +11,10 @@ public class Libro {
     @Column(name = "titulo")
     private String titulo;
 
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "id_empleado")
+    private Empleado empleado;
+
     public Libro(Long isbn, String titulo) {
         this.isbn = isbn;
         this.titulo = titulo;
@@ -32,7 +36,16 @@ public class Libro {
         return "\nLibro{" +
                 "isbn=" + isbn +
                 ", titulo='" + titulo +
+                ", empleado="+(empleado != null ? empleado.getCodigo() : "no hay empleado")+
                 '}';
+    }
+
+    public Empleado getEmpleado() {
+        return empleado;
+    }
+
+    public void setEmpleado(Empleado empleado) {
+        this.empleado = empleado;
     }
 
     public String getTitulo() {

--- a/src/main/java/org/example/test/TestEmpleados.java
+++ b/src/main/java/org/example/test/TestEmpleados.java
@@ -7,6 +7,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.GregorianCalendar;
 import java.util.List;
 
@@ -20,24 +21,11 @@ public class TestEmpleados {
         Libro libro = new Libro(3L, "Diario de Ana Frank");
         Libro libro2 = new Libro(4L, "El caballero de la armadura oxidada");
         man.getTransaction().begin();
-        // Persistimos manualmente los libros
-        man.persist(libro);
-        man.persist(libro2);
-        empleado.addLibro(libro);
-        empleado.addLibro(libro2);
+        empleado.setLibros(Arrays.asList(libro, libro2));
         man.persist(empleado);
         man.getTransaction().commit();
         imprimirTodo();
         man.close();
-
-        man = emf.createEntityManager();
-        man.getTransaction().begin();
-        empleado = man.merge(empleado);
-        empleado.quitarLibro(1);
-        man.getTransaction().commit();
-        imprimirTodo();
-        man.close();
-        System.out.println("Este es el elemento que quedo sin referenciar: "+libro2);
     }
 
     public static void insertInicial(){


### PR DESCRIPTION
este ejemplo de relacion OneToMany bidirecional no aplica la relacion a la base de datos, Talvez porque al ser la entidad dueña la que participa como Many, deberia ser ella la que referencia a la otra entidad pero en el ejemplo asignamos una coleccion de entidades a la entidad del Lado One y esta al tener el atributo cascadeAll permite que se guarden las entidades relacionadas a la base de datos pero no hace la asignacion osea que en la base de datos los registros del lado Many tendran la columna FK que deberia tener el valor de la PK de algun registro del lado One, en realidad lo tiene vacio(null) por lo que creo que lo que importa es que la entidad dueña es la que tiene que hacer la asignacion explicitamente